### PR TITLE
fix: 删除镜像中的.git文件

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ ARG NOVNC_VERSION=v1.3.0
 
 RUN apk update && apk add git
 
-RUN git clone -c advice.detachedHead=false --depth=1 --branch ${NOVNC_VERSION} https://github.com/novnc/noVNC /novnc
+RUN git clone -c advice.detachedHead=false --depth=1 --branch ${NOVNC_VERSION} https://github.com/novnc/noVNC /novnc  && \
+    rm /novnc/.git/config
 
 COPY nginx.conf /etc/nginx/templates/default.conf.template
 


### PR DESCRIPTION
由于部分安全扫描软件认为.git/confg文件被暴露是高危漏洞，所以删除.git文件以减少潜在的安全风险和镜像体积。